### PR TITLE
Switch the tab layouts to "anchor"

### DIFF
--- a/templates/PackageBuilder/home.panel.tpl
+++ b/templates/PackageBuilder/home.panel.tpl
@@ -16,7 +16,8 @@ EB.panel.config = {
 			id: '{$cmpNamespace}-tabs',
 			defaults: { 
 				border: false, 
-				autoHeight: true 
+				autoHeight: true,
+				layout: 'anchor'
 			},
 			border: true,
 			listeners: {

--- a/templates/TransportBuilder/home.panel.tpl
+++ b/templates/TransportBuilder/home.panel.tpl
@@ -16,7 +16,8 @@ EB.panel.config = {
 			id: '{$cmpNamespace}-tabs',
 			defaults: { 
 				border: false, 
-				autoHeight: true 
+				autoHeight: true,
+				layout: 'anchor'
 			},
 			border: true,
 			items: [

--- a/templates/css/css.tpl
+++ b/templates/css/css.tpl
@@ -1,8 +1,4 @@
 <style>
-.x-panel-bbar, .x-toolbar, .x-panel-tbar, .x-toolbar {
-	width: inherit !important;
-}
-
 /* Darker disabled style */
 .eb-disabled {
 	color: #787878;


### PR DESCRIPTION
Hey Jared!

Awesome work with this extra! ;)
This PR is a small tweak that allows ExtJS to use it's own layout system without needing to override it with CSS.

I've just applied this to the PackageBuilder/TransportBuilder home panels, so if I missed grids elsewhere, apologies in advance!

